### PR TITLE
Creating a research philosophies page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@
 source "https://rubygems.org"
 
 gemspec
+
+gem "jekyll", "~> 4.3"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,6 +21,7 @@
                   <strong><a>Rose K. Cersonsky</a> &nbsp(<a href="https://rosecersonsky.com/CV.pdf">CV</a> | <a href="https://www.rosecersonsky.com">Webpage</a>)</strong><br>
                   <strong><a href="/members/">Current Group Members</a><br></strong>
                   <strong><a href="/publications">Publications</a><br></strong>
+                  <strong><a href="/research">Research Philosophies</a><br></strong>
                   <strong><a href="/fun">Shenanigans</a><br></strong>
                   <strong><a href="/internal/">Internal Wiki</a><br></strong>
                   <strong><a href="/join">Join the Cersonsky Lab!</a><br></strong>

--- a/research/index.md
+++ b/research/index.md
@@ -1,0 +1,28 @@
+---
+layout: default
+---
+# Our Research Philosophies
+The Cersonsky group is interested in leveraging data science and molecular simulation to explore molecular systems with changing and complex phase behavior. This research aims to address pertinent fundamental and applied open problems in computational chemical and materials sciences, all to better our world. Our group is committed to conducting research that upholds the principles of open science and adheres to [FAIR](https://www.go-fair.org/fair-principles/) data standards.
+
+# Areas of Interest
+<strong>Machine Learning</strong>
+<ul>
+    <li>For Crystal Structure Prediction: Christian Jorgensen & Grace Lee</li>
+    <li>Molecular Representations and Coarse Graining: Arthur Lin & Lucas Ortengren</li>
+    <li>Machine Learning Potentials: Natalie Hooven</li>
+</ul>
+
+<strong>Molecular Simulation</strong>
+<ul>
+    <li>For Glasses: Charles Carroll</li>
+    <li>For Colloidal Phases: Hwigwang Lim & Caleb Youngwerth</li>
+    <li>For Ionic Liquids: Lisa Je</li>
+    <li>For Melting: Matthew Reuteman</li>
+    <li>For Biological Systems: Zachary Amsterdam</li>
+</ul>
+
+<strong>Chemistry as Data</strong>
+<ul>
+    <li>PCovR/PCovC: Christian Jorgensen & Arthur Lin</li>
+    <li>TDA: Ethan Deutsch & Lisa Je</li>
+</ul>

--- a/research/index.md
+++ b/research/index.md
@@ -14,10 +14,10 @@ The Cersonsky group is interested in leveraging data science and molecular simul
 
 <strong>Molecular Simulation</strong>
 <ul>
-    <li>For Glasses: Charles Carroll</li>
-    <li>For Colloidal Phases: Hwigwang Lim & Caleb Youngwerth</li>
-    <li>For Ionic Liquids: Lisa Je</li>
-    <li>For Melting: Matthew Reuteman</li>
+    <li>For Glasses: <a href="/members/charles_carroll">Charles Carroll</a></li>
+    <li>For Colloidal Phases: <a href="/members/hwigwang_lim">Hwigwang Lim</a> & <a href="/members/caleb_youngwerth">Caleb Youngwerth</a></li>
+    <li>For Ionic Liquids: <a href="/members/lisa_je">Lisa Je</a></li>
+    <li>For Melting: <a href="/members/matthew_reuteman">Matthew Reuteman</a></li>
     <li>For Biological Systems: Zachary Amsterdam</li>
 </ul>
 

--- a/research/index.md
+++ b/research/index.md
@@ -23,6 +23,6 @@ The Cersonsky group is interested in leveraging data science and molecular simul
 
 <strong>Chemistry as Data</strong>
 <ul>
-    <li>PCovR/PCovC: Christian Jorgensen & Arthur Lin</li>
-    <li>TDA: Ethan Deutsch & Lisa Je</li>
+    <li>PCovR/PCovC: <a href="/members/christian_jorgensen">Christian Jorgensen</a> & <a href="/members/arthur_lin">Arthur Lin</a></li>
+    <li>TDA: Ethan Deutsch & <a href="/members/lisa_je">Lisa Je</a></li>
 </ul>

--- a/research/index.md
+++ b/research/index.md
@@ -7,9 +7,9 @@ The Cersonsky group is interested in leveraging data science and molecular simul
 # Areas of Interest
 <strong>Machine Learning</strong>
 <ul>
-    <li>For Crystal Structure Prediction: Christian Jorgensen & Grace Lee</li>
-    <li>Molecular Representations and Coarse Graining: Arthur Lin & Lucas Ortengren</li>
-    <li>Machine Learning Potentials: Natalie Hooven</li>
+    <li>For Crystal Structure Prediction: <a href="/members/christian_jorgensen">Christian Jorgensen</a> & <a href="/members/grace_lee">Grace Lee</a></li>
+    <li>Molecular Representations and Coarse Graining: <a href="/members/arthur_lin">Arthur Lin</a> & <a href="/members/lucas_ortengren">Lucas Ortengren</a></li>
+    <li>Machine Learning Potentials: <a href="/members/natalie_hooven">Natalie Hooven</a></li>
 </ul>
 
 <strong>Molecular Simulation</strong>


### PR DESCRIPTION
Updated the website to have a page "Research Philosophies" listing our group's philosophies and areas of interest (similar to the "Publications" tab that was added). 