### PR TITLE
Vertically scrollable page with other small updates

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,7 +26,7 @@
                   <strong><a href="/internal/">Internal Wiki</a><br></strong>
                   <strong><a href="/join">Join the Cersonsky Lab!</a><br></strong>
                   <br><strong><a href="https://github.com/cersonsky-lab"> GitHub</a>&nbsp; | &nbsp; <a href="https://twitter.com/LabOfScience"> Twitter</a><br></strong>
-                  Last Updated: 2/18/2025
+                  Last Updated: 4/22/2025
 </header>
           <section>
 

--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -3,7 +3,7 @@
 
 body {
   background-color: #fff;
-  padding:50px;
+  padding: 20px 50px 50px 50px;
   font: 14px/1.5 "Noto Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
   color:#727272;
   font-weight:400;

--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -3,7 +3,7 @@
 
 body {
   background-color: #fff;
-  padding: 20px 50px 50px 50px;
+  padding: 35px 50px 50px 50px;
   font: 14px/1.5 "Noto Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
   color:#727272;
   font-weight:400;
@@ -219,6 +219,12 @@ footer {
   position:fixed;
   bottom:50px;
   -webkit-font-smoothing:subpixel-antialiased;
+}
+
+@media print, screen and (max-height: 715px) {
+  header, section, footer {
+    position:static;
+  }
 }
 
 @media print, screen and (max-width: 960px) {

--- a/research/index.md
+++ b/research/index.md
@@ -18,11 +18,11 @@ The Cersonsky group is interested in leveraging data science and molecular simul
     <li>For Colloidal Phases: <a href="/members/hwigwang_lim">Hwigwang Lim</a> & <a href="/members/caleb_youngwerth">Caleb Youngwerth</a></li>
     <li>For Ionic Liquids: <a href="/members/lisa_je">Lisa Je</a></li>
     <li>For Melting: <a href="/members/matthew_reuteman">Matthew Reuteman</a></li>
-    <li>For Biological Systems: Zachary Amsterdam</li>
+    <li>For Biological Systems:<a href="/members/zachary_amsterdam">Zachary Amsterdam</a></li>
 </ul>
 
 <strong>Chemistry as Data</strong>
 <ul>
     <li>PCovR/PCovC: <a href="/members/christian_jorgensen">Christian Jorgensen</a> & <a href="/members/arthur_lin">Arthur Lin</a></li>
-    <li>TDA: Ethan Deutsch & <a href="/members/lisa_je">Lisa Je</a></li>
+    <li>TDA: <a href="/members/ethan_deutsch">Ethan Deutsch</a> & <a href="/members/lisa_je">Lisa Je</a></li>
 </ul>


### PR DESCRIPTION
Now the webpage is scrollable when the maximum visible height is smaller than the height of the header (banner on left). In addition, I adjusted the upper margin of the page, added the links to the members pages of recently added members (Zachary and Ethan) in Research Philosophy section, and updated the ticker.

This will close the issue #59.