### PR TITLE
Fixing blogpost urls

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,7 +26,7 @@
                   <strong><a href="{{ site.baseurl }}/internal/">Internal Wiki</a><br></strong>
                   <strong><a href="{{ site.baseurl }}/join">Join the Cersonsky Lab!</a><br></strong>
                   <br><strong><a href="https://github.com/cersonsky-lab"> GitHub</a>&nbsp; | &nbsp; <a href="https://twitter.com/LabOfScience"> Twitter</a><br></strong>
-                  Last Updated: 6/12/2025
+                  Last Updated: 6/18/2025
 </header>
           <section>
 

--- a/internal/index.md
+++ b/internal/index.md
@@ -27,7 +27,7 @@ layout: default
 <ul>
   {% for post in site.posts %}
     <li>
-      <a href="{{ site.baseurl }}/{{ post.url }}">{{ post.date | date: "%B %d, %Y: " }}{{ post.title }}</a>
+      <a href="{{ post.url }}">{{ post.date | date: "%B %d, %Y: " }}{{ post.title }}</a>
     </li>
   {% endfor %}
 </ul>


### PR DESCRIPTION
The blogpost links are currently broken on the website. This should fix them.

Addresses issue #79 